### PR TITLE
docs: add OpenCode integration instructions

### DIFF
--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -29,6 +29,9 @@
     },
     "md024": {
       "enabled": false
+    },
+    "md023": {
+      "enabled": false
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,17 @@ vb validate || ./scripts/ftr-validate.sh
 
 The `.cursor/rules/virtualboard.mdc` file enables automatic VirtualBoard integration in Cursor IDE.
 
+### OpenCode Integration
+
+VirtualBoard agents can be integrated into OpenCode:
+
+**Setup (one-time):**
+```bash
+mkdir -p .opencode/agent && cp -Rf .virtualboard/agents .opencode/agent
+```
+
+Then reload OpenCode to make the agents available. This copies all agent role definitions, commands, and shared rules to OpenCode's agent directory.
+
 ### Claude Code Plugin
 
 VirtualBoard is available as a Claude Code plugin. Install via:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ To enable VirtualBoard across all your projects in Cursor, add the rule globally
 
 **Note:** Project-level rules (`.cursor/rules/`) take precedence over global rules. If you have both, the project-level rule will be used.
 
+## OpenCode Integration
+
+VirtualBoard agents can be easily integrated into [OpenCode](https://github.com/stackblitz/opencode), an open source AI coding tool.
+
+To enable VirtualBoard agents in OpenCode:
+
+1. **Copy agent files to OpenCode directory:**
+   ```bash
+   mkdir -p .opencode/agent && cp -Rf .virtualboard/agents .opencode/agent
+   ```
+
+2. **Reload OpenCode:**
+   Restart your OpenCode session to load the agents.
+
+3. **Use agents:**
+   Once reloaded, the VirtualBoard agents (PM, Architect, Frontend Dev, Backend Dev, QA, etc.) will be available in OpenCode.
+
+**What gets copied:**
+- All agent role definitions (`agents/*.md`)
+- Agent command system (`prompts/agents/`)
+- Shared rules of engagement (`agents/RULES.md`)
+
+**Benefits:**
+- Native agent integration
+- Quick access to specialized agent commands
+- Consistent agent behavior
+- No additional configuration needed
+
 ## Implementation
 
 The system is built entirely with bash scripts, eliminating the need for Node.js or npm dependencies. This approach provides:

--- a/docs/.opencode/skill/virtualboard/SKILL.md
+++ b/docs/.opencode/skill/virtualboard/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: virtualboard
+description: Feature specification and workflow management system for multi-agent AI collaboration with structured Markdown-first approach to software development lifecycle
+license: MIT
+compatibility: opencode
+metadata:
+  version: 1.0.0
+  category: workflow
+  audience: all-agents
+---
+
+# Virtual Board
+
+VirtualBoard is a feature specification and workflow management system designed for multi-agent AI collaboration. It provides a structured, Markdown-first approach to managing software development features through their complete lifecycle using specialized AI agent roles.
+
+## Critical First Step: Agent Role Adoption
+
+**BEFORE starting ANY task, you MUST:**
+
+1. **Check for agent directories** in this order (first found takes precedence):
+   ```bash
+   # Check for agents directory
+   ls -la agents/ 2>/dev/null || ls -la .virtualboard/agents/ 2>/dev/null
+   ```
+
+2. **If agent directories exist:**
+   - Read `agents/AGENTS.md` to understand the agent system
+   - **Analyze the current task** to determine the appropriate agent role
+   - Read the specific role file (e.g., `agents/frontend_dev.md`)
+   - **Announce your adopted role** (e.g., "I am working as a Frontend Developer agent")
+   - Follow that agent's specific workflow throughout the task
+
+3. **Available Agent Roles:**
+   - `agents/pm.md` → Sprint planning, progress tracking, backlog grooming
+   - `agents/architect.md` → Architecture design, technical decisions
+   - `agents/backend_dev.md` → APIs, databases, server-side logic
+   - `agents/frontend_dev.md` → UI components, client-side interactions
+   - `agents/fullstack_dev.md` → End-to-end features
+   - `agents/qa.md` → Testing, quality assurance, browser automation
+   - `agents/devops_engineer.md` → CI/CD, deployment, infrastructure
+   - `agents/security_compliance_engineer.md` → Security reviews, threat modeling
+   - `agents/data_analytics_engineer.md` → Data pipelines, analytics
+   - `agents/ux_product_designer.md` → User journeys, wireframes
+
+## Feature Lifecycle
+
+Features move through these states:
+```
+backlog → in-progress → review → done
+              ↓
+           blocked (when waiting on dependencies)
+```
+
+Each feature is a Markdown file in `features/{status}/` with:
+- YAML frontmatter containing metadata (id, status, owner, priority, etc.)
+- Structured sections (Summary, Requirements, Acceptance Criteria, etc.)
+- Implementation notes and links
+
+## Critical Rules
+
+### When Moving Features Between Folders
+
+**YOU MUST UPDATE THE FRONTMATTER:**
+
+```yaml
+status: in-progress  # MUST match destination folder name
+owner: backend_dev   # MUST update when claiming/releasing ownership
+updated: 2025-12-29  # MUST update to today's date (YYYY-MM-DD)
+```
+
+**Failure to update frontmatter will cause validation errors!**
+
+### Immutable Fields
+
+**NEVER change these fields:**
+- `id` - Feature identifier (e.g., FTR-0001)
+- `created` - Original creation date
+- Filename must match the id
+
+## Using Virtual Board
+
+### Check CLI Availability
+
+```bash
+# Check if VirtualBoard CLI is installed
+command -v vb &> /dev/null && echo "CLI available" || echo "Use scripts"
+```
+
+### Common Operations
+
+**Create New Feature (as PM agent):**
+```bash
+# Using CLI
+vb new "Feature Title" label1 label2
+
+# Using scripts
+./scripts/ftr-new.sh "Feature Title" label1 label2
+```
+
+**Move Feature Between States:**
+```bash
+# Using CLI (recommended)
+vb move FTR-0001 in-progress --owner backend_dev
+
+# Using scripts
+./scripts/ftr-move.sh FTR-0001 in-progress backend_dev
+```
+
+**IMPORTANT:** After moving, manually verify frontmatter is updated!
+
+**Validate All Features:**
+```bash
+# Using CLI
+vb validate
+
+# Using scripts
+./scripts/ftr-validate.sh
+```
+
+**Generate Feature Index:**
+```bash
+# Using CLI
+vb index
+
+# Using scripts
+./scripts/ftr-index.sh
+```
+
+### Workflow Example
+
+1. **Check for work:**
+   ```bash
+   cat features/INDEX.md
+   ```
+
+2. **Adopt appropriate agent role:**
+   ```bash
+   cat agents/AGENTS.md
+   cat agents/backend_dev.md  # Read specific role file
+   ```
+
+3. **Claim a feature:**
+   ```bash
+   vb move FTR-0001 in-progress --owner backend_dev
+   # Then edit features/in-progress/FTR-0001-feature-name.md
+   # Update frontmatter: status, owner, updated
+   ```
+
+4. **Work on implementation:**
+   - Update feature file's Implementation Notes section
+   - Link commits and PRs in the Links section
+   - Reference feature ID (FTR-####) in all commits
+
+5. **Move to review when complete:**
+   ```bash
+   vb move FTR-0001 review
+   # Update frontmatter: status, updated
+   ```
+
+6. QA validates and moves to done
+
+## Agent Commands System
+
+Each agent role has specialized commands for common tasks. Commands are triggered by specific phrases and produce structured outputs.
+
+**Check Available Commands:**
+```bash
+cat prompts/agents/{role}/README.md
+```
+
+**Example Commands:**
+- `GPP` (PM) → Generate Project Progress Report
+- `GAD` (Architect) → Generate Architecture Decision
+- `GTP` (QA) → Generate Test Plan
+- `GBAT` (QA) → Generate Browser Automation Tests (Playwright)
+- `GAE` (Backend) → Generate API Endpoint
+
+## Directory Structure
+
+```
+features/
+├── backlog/         # Unassigned features
+├── in-progress/     # Features being developed
+├── blocked/         # Features waiting on dependencies
+├── review/          # Features ready for review
+├── done/            # Completed features
+└── INDEX.md         # Auto-generated (don't edit manually)
+
+agents/              # Agent role definitions
+├── AGENTS.md        # Role selection guide
+├── RULES.md         # Shared rules
+└── [role].md        # Individual role files
+
+prompts/             # Agent commands
+├── AGENTS.md        # Command system overview
+├── agents/          # Role-specific commands
+│   ├── pm/
+│   ├── architect/
+│   ├── backend_dev/
+│   ├── frontend_dev/
+│   ├── qa/
+│   └── [other roles]/
+└── common/          # Shared templates
+
+scripts/             # Automation scripts
+├── ftr-new.sh
+├── ftr-move.sh
+├── ftr-validate.sh
+├── ftr-index.sh
+└── install-vb-cli.sh
+
+templates/           # Templates for features and PRs
+├── feature.md
+├── pr-template.md
+└── rules.yml
+
+schemas/             # Validation schemas
+└── frontmatter.schema.json
+```
+
+## Validation Rules
+
+The system enforces:
+- Frontmatter must match JSON schema
+- File location MUST match frontmatter `status` field
+- No circular dependencies
+- Dependencies must be resolved before moving to in-progress
+- One owner per feature (no conflicts)
+
+**Always validate before committing:**
+```bash
+vb validate || ./scripts/ftr-validate.sh
+```
+
+## Best Practices
+
+### DO
+- ✅ Always read agent files before starting work
+- ✅ Always update frontmatter when moving files (status, owner, updated)
+- ✅ Always validate before committing
+- ✅ Use the CLI (`vb`) when available
+- ✅ Follow the agent's specific workflow for your adopted role
+- ✅ Reference feature IDs (FTR-####) in all commits and PRs
+- ✅ Link PRs and commits in feature's Links section
+
+### DON'T
+- ❌ Never edit INDEX.md manually (it's auto-generated)
+- ❌ Never change feature ID or filename (immutable)
+- ❌ Never skip frontmatter updates when moving files
+- ❌ Never assume agent behavior (always read the role file)
+- ❌ Never work on features owned by other agents
+
+## When to Use This Skill
+
+Use VirtualBoard when:
+- Working in a repository with `features/` or `.virtualboard/` directories
+- You see references to feature IDs like FTR-0001
+- The user mentions agent roles (PM, architect, backend dev, etc.)
+- You need to create or manage feature specifications
+- You're collaborating with other AI agents on a project
+- The user asks you to adopt a specific agent role
+
+## Troubleshooting
+
+**"Feature already owned"**
+→ Another agent is working on it, find another feature in backlog
+
+**"Circular dependency"**
+→ Dependencies form a loop, human must resolve
+
+**"Invalid transition"**
+→ Not allowed to move to that status, check `agents/RULES.md`
+
+**"Location mismatch"**
+→ File location doesn't match frontmatter status field
+
+**Scripts permission denied**
+→ Run `chmod +x scripts/*.sh`
+
+## Quick Start for New Users
+
+If this is your first time in a VirtualBoard repository:
+
+```bash
+# 1. Check if CLI is installed
+command -v vb
+
+# 2. If not, install it (optional but recommended)
+./scripts/install-vb-cli.sh
+
+# 3. Read the agent system overview
+cat agents/AGENTS.md
+
+# 4. Check available work
+cat features/INDEX.md
+
+# 5. Adopt appropriate agent role based on task
+cat agents/backend_dev.md  # Example
+
+# 6. Start working!
+```
+
+## QA Agent Special: Browser Automation Testing
+
+The QA agent has a powerful **GBAT** command for comprehensive browser testing:
+
+**Usage:** `GBAT for FTR-0042`
+
+**What it does:**
+1. Generate test cases in markdown
+2. Generate Playwright automation scripts with Page Object Model
+3. Execute tests across browsers (Chrome, Firefox, Safari)
+4. Generate detailed reports (markdown/HTML)
+
+See `prompts/agents/qa/examples/GBAT-example.md` for complete walkthrough.
+
+## Integration
+
+VirtualBoard has zero dependencies (pure bash scripts) and integrates with:
+- Claude Code (via `.claude/CLAUDE.md` and plugins)
+- Cursor IDE (via `.cursor/rules/virtualboard.mdc`)
+- OpenCode (via this SKILL.md)
+- Any CI/CD pipeline (validation scripts)
+
+## Resources
+
+- Feature template: `templates/feature.md`
+- Agent rules: `agents/RULES.md`
+- Schema validation: `schemas/frontmatter.schema.json`
+- Session handoff template: `prompts/common/session-handoff.md`
+
+---
+
+**Remember:** Always start by adopting the appropriate agent role for your task. This is not optional—it's fundamental to how VirtualBoard works!

--- a/docs/index.html
+++ b/docs/index.html
@@ -366,6 +366,85 @@
       font-weight: 600;
     }
 
+    /* Tab styles */
+    .tabs {
+      display: flex;
+      gap: 0.5rem;
+      border-bottom: 2px solid var(--border);
+      margin-bottom: 2rem;
+      overflow-x: auto;
+    }
+
+    .tab-button {
+      padding: 0.75rem 1.5rem;
+      border: none;
+      background: transparent;
+      color: var(--muted);
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      border-bottom: 3px solid transparent;
+      margin-bottom: -2px;
+      transition: all 0.2s ease;
+      white-space: nowrap;
+    }
+
+    .tab-button:hover {
+      color: var(--text);
+      background: rgba(0, 212, 255, 0.05);
+    }
+
+    .tab-button.active {
+      color: var(--accent-dark);
+      border-bottom-color: var(--accent);
+    }
+
+    .tab-content {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .code-block {
+      background: var(--bg);
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+      margin: 1.5rem 0;
+      border: 1px solid var(--border);
+      font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+      font-size: 0.9rem;
+      overflow-x: auto;
+    }
+
+    .code-block code {
+      color: var(--accent-dark);
+      font-weight: 600;
+    }
+
+    .info-box {
+      padding: 1rem;
+      background: rgba(0, 212, 255, 0.1);
+      border-left: 3px solid var(--accent);
+      border-radius: 0.5rem;
+      margin: 1.5rem 0;
+    }
+
+    .success-box {
+      padding: 1rem;
+      background: rgba(50, 215, 75, 0.1);
+      border-left: 3px solid var(--accent-secondary);
+      border-radius: 0.5rem;
+      margin: 1.5rem 0;
+    }
+
     @media (prefers-color-scheme: dark) {
       :root {
         --bg: #0f172a;
@@ -448,67 +527,134 @@
 
   <main class="container">
     <section>
-      <h2>Claude Code Plugin</h2>
-      <p>VirtualBoard is now available as a <span class="highlight">Claude Code plugin</span>! Install it directly in Claude Code to get instant access to 10 specialized AI agent roles and 30+ specialized commands.</p>
-      <div style="background: var(--bg); border-radius: 0.75rem; padding: 1.25rem; margin: 1.5rem 0; border: 1px solid var(--border);">
-        <code style="color: var(--accent-dark); font-weight: 600;">claude plugin marketplace add virtualboard/template-base<br />claude plugin install virtualboard</code>
+      <h2>IDE Integration</h2>
+      <p>VirtualBoard integrates seamlessly with multiple AI-powered development tools. Choose your IDE below to get started:</p>
+
+      <div class="tabs">
+        <button class="tab-button active" onclick="switchTab(event, 'claude-code')">Claude Code</button>
+        <button class="tab-button" onclick="switchTab(event, 'cursor')">Cursor</button>
+        <button class="tab-button" onclick="switchTab(event, 'opencode')">OpenCode</button>
       </div>
-      <div class="grid two">
-        <article>
-          <h3>10 Specialized Agent Roles</h3>
-          <ul>
-            <li>Project Manager</li>
-            <li>System Architect</li>
-            <li>Backend/Frontend/Fullstack Developer</li>
-            <li>QA Engineer</li>
-            <li>DevOps Engineer</li>
-            <li>Security Engineer</li>
-            <li>Data Engineer</li>
-            <li>UX/Product Designer</li>
+
+      <div id="claude-code" class="tab-content active">
+        <h3>Claude Code Plugin</h3>
+        <p>VirtualBoard is available as a <span class="highlight">Claude Code plugin</span>! Install it directly to get instant access to 10 specialized AI agent roles and 30+ specialized commands.</p>
+
+        <div class="code-block">
+          <code>claude plugin marketplace add virtualboard/template-base<br>claude plugin install virtualboard</code>
+        </div>
+
+        <div class="grid two">
+          <article>
+            <h3>10 Specialized Agent Roles</h3>
+            <ul>
+              <li>Project Manager</li>
+              <li>System Architect</li>
+              <li>Backend/Frontend/Fullstack Developer</li>
+              <li>QA Engineer</li>
+              <li>DevOps Engineer</li>
+              <li>Security Engineer</li>
+              <li>Data Engineer</li>
+              <li>UX/Product Designer</li>
+            </ul>
+          </article>
+          <article>
+            <h3>30+ Agent Commands</h3>
+            <ul>
+              <li>GPP - Project Progress Report</li>
+              <li>GBG - Backlog Grooming</li>
+              <li>GAD - Architecture Diagram</li>
+              <li>GAE - API Endpoint</li>
+              <li>GC - Component Generation</li>
+              <li>GTP - Test Plan</li>
+              <li>And 23+ more specialized commands!</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="info-box">
+          <strong>Plugin Benefits:</strong> Automatic updates, built-in validation, and seamless integration with Claude Code's agent system.
+        </div>
+      </div>
+
+      <div id="cursor" class="tab-content">
+        <h3>Cursor IDE Integration</h3>
+        <p>VirtualBoard includes a <code>.cursor/rules/virtualboard.mdc</code> file that enables automatic integration with <a href="https://cursor.sh/" target="_blank" rel="noreferrer" style="color: var(--accent);">Cursor IDE</a>.</p>
+
+        <div class="grid two">
+          <article>
+            <h3>Project-Level Installation</h3>
+            <p>Copy the <code>.cursor</code> folder to your project root to enable VirtualBoard for that specific project:</p>
+            <div class="code-block">
+              <code>cp -r .cursor /path/to/your/project/</code>
+            </div>
+            <p><strong>Recommended for:</strong> Single project or project-specific customizations</p>
+          </article>
+
+          <article>
+            <h3>Global Installation</h3>
+            <p>Add the VirtualBoard rule globally in Cursor Settings:</p>
+            <ol style="font-size: 0.95rem; line-height: 1.7;">
+              <li>Open Cursor Settings (Cmd/Ctrl + ,)</li>
+              <li>Navigate to "Cursor Settings" → "Rules for AI"</li>
+              <li>Click "Edit in settings.json"</li>
+              <li>Add the VirtualBoard rule configuration</li>
+            </ol>
+            <p><strong>Recommended for:</strong> Using VirtualBoard across all your projects</p>
+          </article>
+        </div>
+
+        <div class="info-box">
+          <strong>Note:</strong> Project-level rules (<code>.cursor/rules/</code>) take precedence over global rules.
+        </div>
+      </div>
+
+      <div id="opencode" class="tab-content">
+        <h3>OpenCode Integration</h3>
+        <p>VirtualBoard agents can be easily integrated into <a href="https://github.com/stackblitz/opencode" target="_blank" rel="noreferrer" style="color: var(--accent);">OpenCode</a>, an open source AI coding tool.</p>
+
+        <h4>One-Time Setup</h4>
+        <p>Copy the VirtualBoard agent files to OpenCode's agent directory:</p>
+        <div class="code-block">
+          <code>mkdir -p .opencode/agent && cp -Rf .virtualboard/agents .opencode/agent</code>
+        </div>
+
+        <h4>Activate the Agents</h4>
+        <p>Restart your OpenCode session to load the agents.</p>
+
+        <div class="success-box">
+          <strong>What Gets Copied:</strong>
+          <ul style="margin: 0.5rem 0 0 0; padding-left: 1.5rem;">
+            <li>All agent role definitions (<code>agents/*.md</code>)</li>
+            <li>Agent command system (<code>prompts/agents/</code>)</li>
+            <li>Shared rules of engagement (<code>agents/RULES.md</code>)</li>
           </ul>
-        </article>
-        <article>
-          <h3>30+ Agent Commands</h3>
-          <ul>
-            <li>GPP - Project Progress Report</li>
-            <li>GBG - Backlog Grooming</li>
-            <li>GAD - Architecture Diagram</li>
-            <li>GAE - API Endpoint</li>
-            <li>GC - Component Generation</li>
-            <li>GTP - Test Plan</li>
-            <li>And 23+ more specialized commands!</li>
-          </ul>
-        </article>
+        </div>
+
+        <h4>Using the Agents</h4>
+        <p>Once reloaded, all VirtualBoard agents (PM, Architect, Frontend Dev, Backend Dev, QA, etc.) will be available in OpenCode.</p>
+
+        <div class="grid two">
+          <article>
+            <h3>Benefits</h3>
+            <ul>
+              <li>Native agent integration</li>
+              <li>Quick access to specialized commands</li>
+              <li>Consistent agent behavior</li>
+              <li>No additional configuration</li>
+            </ul>
+          </article>
+          <article>
+            <h3>Available Agents</h3>
+            <ul>
+              <li>All 10 specialized roles</li>
+              <li>30+ agent commands</li>
+              <li>Feature lifecycle management</li>
+              <li>Automated validation</li>
+            </ul>
+          </article>
+        </div>
       </div>
-    </section>
-
-    <section>
-      <h2>Cursor IDE Integration</h2>
-      <p>VirtualBoard includes a <code>.cursor/rules/virtualboard.mdc</code> file that enables automatic integration with <a href="https://cursor.sh/" target="_blank" rel="noreferrer" style="color: var(--accent);">Cursor IDE</a>. This rule tells Cursor to use the VirtualBoard workflow and agent system.</p>
-
-      <div class="grid two">
-        <article>
-          <h3>Project-Level Installation</h3>
-          <p>Copy the <code>.cursor</code> folder to your project root to enable VirtualBoard for that specific project:</p>
-          <div style="background: var(--bg-alt); border-radius: 0.5rem; padding: 1rem; margin: 1rem 0; border: 1px solid var(--border); font-family: monospace; font-size: 0.9rem;">
-            cp -r .cursor /path/to/your/project/
-          </div>
-          <p><strong>Recommended for:</strong> Single project or project-specific customizations</p>
-        </article>
-
-        <article>
-          <h3>Global Installation</h3>
-          <p>Add the VirtualBoard rule globally in Cursor Settings:</p>
-          <ol style="font-size: 0.95rem; line-height: 1.7;">
-            <li>Open Cursor Settings (Cmd/Ctrl + ,)</li>
-            <li>Navigate to "Cursor Settings" → "Rules for AI"</li>
-            <li>Click "Edit in settings.json"</li>
-            <li>Add the VirtualBoard rule configuration</li>
-          </ol>
-          <p><strong>Recommended for:</strong> Using VirtualBoard across all your projects</p>
-        </article>
-      </div>
-      <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(0, 212, 255, 0.1); border-left: 3px solid var(--accent); border-radius: 0.5rem;"><strong>Note:</strong> Project-level rules (<code>.cursor/rules/</code>) take precedence over global rules.</p>
     </section>
 
     <section>
@@ -567,5 +713,21 @@
   <footer>
     <p>VirtualBoard Template · Released under the MIT License</p>
   </footer>
+
+  <script>
+    function switchTab(event, tabId) {
+      // Hide all tab contents
+      const tabContents = document.querySelectorAll('.tab-content');
+      tabContents.forEach(content => content.classList.remove('active'));
+
+      // Remove active class from all buttons
+      const tabButtons = document.querySelectorAll('.tab-button');
+      tabButtons.forEach(button => button.classList.remove('active'));
+
+      // Show selected tab and mark button as active
+      document.getElementById(tabId).classList.add('active');
+      event.currentTarget.classList.add('active');
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Add documentation for integrating VirtualBoard agents with OpenCode, an open source AI coding tool. Users can now copy agent files to .opencode/agent directory to enable all VirtualBoard agent roles (PM, Architect, Frontend Dev, Backend Dev, QA, etc.) in OpenCode.

Also disable MD023 pymarkdown rule to allow YAML frontmatter in markdown files.

Generated with [Virtual Board](https://github.com/virtualboard/template-base)